### PR TITLE
Adjust lottery timing

### DIFF
--- a/app/(tabs)/home.js
+++ b/app/(tabs)/home.js
@@ -16,8 +16,10 @@ import useServerTime from '../../hooks/useServerTime';
 
 const { width, height } = Dimensions.get('window');
 const LOTTERY_DURATION = 300000; // 5 minutes in milliseconds
-const BETTING_CLOSE_TIME = 240000; // Close betting at 4:00 (4 minutes)
-const WINNER_CHECK_START = 270000; // Start checking for winner at 4:30 (270 seconds)
+// Betting closes 30 seconds before the draw
+const BETTING_CLOSE_TIME = 270000; // 4 minutes 30 seconds in milliseconds
+// Start checking the winner right at the draw time
+const WINNER_CHECK_START = 300000; // 5 minutes in milliseconds
 const WINNER_CHECK_INTERVAL = 2000; // Check for winner every 2 seconds
 const SPIN_DURATION = 85;
 


### PR DESCRIPTION
## Summary
- tweak bet closing time to 4:30
- check winner at the draw (5:00)

## Testing
- `npm test -- -i` *(fails: `jest` not found)*
- `npm run lint` *(fails: `expo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f635f8af8833387d100c2a0721b82